### PR TITLE
.grid-title -> line-height: 1.5

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -34,7 +34,7 @@
 .grid-title {
   display: block;
   color: #333;
-	line-height: 1.5;
+  line-height: 1.5;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -34,6 +34,7 @@
 .grid-title {
   display: block;
   color: #333;
+	line-height: 1.5;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                         <div class="block-grid-wrapper">
                             {% include block-grid.html url="https://scc.ustc.edu.cn/" title="超算中心" icon="fad fa-server" %}
                             {% include block-grid.html url="https://mirrors.ustc.edu.cn/" title="开源软件镜像" icon="fab fa-linux" %}
-                            {% include block-grid.html url="https://git.lug.ustc.edu.cn/" title="Gitlab" icon="fab fa-git-alt" %}
+                            {% include block-grid.html url="https://git.lug.ustc.edu.cn/" title="GitLab" icon="fab fa-git-alt" %}
                             {% include block-grid.html url="https://oj.ustc.edu.cn/" title="Online Judge" icon="fad fa-code" %}
                             <div class="clear"></div>
                         </div>


### PR DESCRIPTION
Solves vertical alignment issue with Roboto font, e.g. (image from Hypercube):

![image](https://user-images.githubusercontent.com/7273074/97670259-cb319780-1ac0-11eb-866c-466aa3456491.png)
