### PR TITLE
替换“校车时间表”的链接

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
                             {% include block-grid.html url="https://ustcforum.com/" title="南七茶馆" icon="fad fa-mug-tea" %}
                             {% include block-grid.html url="http://ustcflyer.com/" title="飞跃网站" icon="fad fa-graduation-cap" %}
                             {% include block-grid.html url="https://qq.ustc.life/" title="QQ 号证明" icon="fab fa-qq" %}
-                            {% include block-grid.html url="http://lib.ustc.edu.cn/weixin/%E6%A0%A1%E5%9B%AD%E7%8F%AD%E8%BD%A6%E6%97%B6%E5%88%BB%E8%A1%A8/" title="校车时刻表" icon="fad fa-bus-school" %}
+                            {% include block-grid.html url="http://home.ustc.edu.cn/~hr874589148/last/test-site/schoolBus.html" title="校车时刻表" icon="fad fa-bus-school" %}
                             <div class="clear"></div>
                         </div>
                     </div>


### PR DESCRIPTION
新链接为 <http://home.ustc.edu.cn/~hr874589148/last/test-site/schoolBus.html>

替换的理由：

1. 旧链接只有本部校车的时间表（一张图片），新链接不仅有本部的时间表，也有高新校区的时间表
2. 新链接对 Google 的 SEO 更友好（解读：Google 搜索 `校车 site:ustc.edu.cn` 返回的第一个结果）